### PR TITLE
NLog 4.5.0 with NetStandard13 support

### DIFF
--- a/Rebus.NLog.Tests/ContextVariableWorks.cs
+++ b/Rebus.NLog.Tests/ContextVariableWorks.cs
@@ -24,7 +24,7 @@ namespace Rebus.NLog.Tests
         {
             // ${basedir}/logs/logfile.log
 
-#if NETSTANDARD1_5
+#if NETSTANDARD1_3
             var logFilePath = Path.Combine(AppContext.BaseDirectory, "logs", "logfile.log");
 #else
             var logFilePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "logs", "logfile.log");

--- a/Rebus.NLog.Tests/Rebus.NLog.Tests.csproj
+++ b/Rebus.NLog.Tests/Rebus.NLog.Tests.csproj
@@ -5,7 +5,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Rebus.NLog.Tests</RootNamespace>
     <AssemblyName>Rebus.NLog.Tests</AssemblyName>
-    <TargetFrameworks>net45;netstandard1.5</TargetFrameworks>
+    <TargetFrameworks>net452;netcoreapp11</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -29,12 +29,12 @@
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net45' ">
     <DefineConstants>NET45</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.5' ">
-    <DefineConstants>NETSTANDARD1_5</DefineConstants>
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp11' ">
+    <DefineConstants>NETSTANDARD1_3</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Rebus.NLog\Rebus.NLog.csproj" />
-    <PackageReference Include="nlog" Version="4.5.0-rc04" />
+    <PackageReference Include="nlog" Version="4.5.0" />
     <PackageReference Include="nunit" Version="3.7.1" />
     <PackageReference Include="rebus" Version="4.0.0" />
     <PackageReference Include="rebus.tests.contracts" Version="4.0.0" />

--- a/Rebus.NLog/NLog/NLogLoggerFactory.cs
+++ b/Rebus.NLog/NLog/NLogLoggerFactory.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using NLog;
 using Rebus.Logging;
+using LogLevel = NLog.LogLevel;
 
 namespace Rebus.NLog.NLog
 {
@@ -24,32 +25,42 @@ namespace Rebus.NLog.NLog
 
             public void Debug(string message, params object[] objs)
             {
-                _logger.Debug(_loggerFactory.RenderString(message, objs));
+                Log(LogLevel.Debug, null, message, objs);
             }
 
             public void Info(string message, params object[] objs)
             {
-                _logger.Info(_loggerFactory.RenderString(message, objs));
+                Log(LogLevel.Info, null, message, objs);
             }
 
             public void Warn(string message, params object[] objs)
             {
-                _logger.Warn(_loggerFactory.RenderString(message, objs));
+                Log(LogLevel.Warn, null, message, objs);
             }
 
             public void Warn(Exception exception, string message, params object[] objs)
             {
-                _logger.Warn(exception, _loggerFactory.RenderString(message, objs));
+                Log(LogLevel.Warn, exception, message, objs);
             }
 
             public void Error(string message, params object[] objs)
             {
-                _logger.Error(_loggerFactory.RenderString(message, objs));
+                Log(LogLevel.Error, null, message, objs);
             }
 
             public void Error(Exception exception, string message, params object[] objs)
             {
-                _logger.Error(exception, _loggerFactory.RenderString(message, objs));
+                Log(LogLevel.Error, exception, message, objs);
+            }
+
+            private void Log(LogLevel logLevel, Exception exception, string message, object[] objs)
+            {
+                // Skip RenderString if no one is listening
+                if (_logger.IsEnabled(logLevel))
+                {
+                    // Allow NLog callsite to work, by providing typeof(NLogLogger)
+                    _logger.Log(typeof(NLogLogger), LogEventInfo.Create(logLevel, _logger.Name, exception, null, _loggerFactory.RenderString(message, objs)));
+                }
             }
         }
     }

--- a/Rebus.NLog/Rebus.NLog.csproj
+++ b/Rebus.NLog/Rebus.NLog.csproj
@@ -5,7 +5,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Rebus.NLog</RootNamespace>
     <AssemblyName>Rebus.NLog</AssemblyName>
-    <TargetFrameworks>net45;netstandard1.5</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard1.3</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <Authors>mookid8000</Authors>
     <PackageLicenseUrl>https://raw.githubusercontent.com/rebus-org/Rebus/master/LICENSE.md</PackageLicenseUrl>
@@ -39,7 +39,7 @@
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net45' ">
     <DefineConstants>NET45</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.5' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
     <DefineConstants>NETSTANDARD1_5</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
@@ -47,7 +47,7 @@
     <None Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="nlog" Version="4.5.0-rc04" />
+    <PackageReference Include="nlog" Version="4.5.0" />
     <PackageReference Include="rebus" Version="4.0.0" />
   </ItemGroup>
   <Target Name="PreBuild" BeforeTargets="PreBuildEvent">


### PR DESCRIPTION
---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
