### PR TITLE
#5 fix url

### DIFF
--- a/Rebus.NLog/Rebus.NLog.csproj
+++ b/Rebus.NLog/Rebus.NLog.csproj
@@ -8,7 +8,7 @@
 		<PackageDescription>NLog-based logger integration for Rebus</PackageDescription>
 		<Copyright>Copyright Rebus FM ApS 2012</Copyright>
 		<PackageTags>rebus nlog logging</PackageTags>
-		<RepositoryUrl>https://github.com/rebus-org/Rebus</RepositoryUrl>
+		<RepositoryUrl>https://github.com/rebus-org/Rebus.NLog</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 		<RootNamespace>Rebus</RootNamespace>
 		<PackageIcon>little_rebusbus2_copy-500x500.png</PackageIcon>


### PR DESCRIPTION
---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.

Closes #5 